### PR TITLE
Tidy up target index calculation

### DIFF
--- a/lib/src/androidTest/kotlin/dev/chrisbanes/snapper/InstrumentedSnapperFlingLazyColumnTest.kt
+++ b/lib/src/androidTest/kotlin/dev/chrisbanes/snapper/InstrumentedSnapperFlingLazyColumnTest.kt
@@ -52,9 +52,14 @@ class InstrumentedSnapperFlingLazyColumnTest(
         fun data() = parameterizedParams()
             // maxScrollDistanceDp
             .combineWithParameters(
-                // We add 4dp on to cater for itemSpacing
+                // We add 4dp on to cater for item spacing
                 1 * (ItemSize.value + 4),
                 4 * (ItemSize.value + 4),
+                // We also test without adding the item spacing. Key use cases like
+                // Accompanist Pager do not add the item spacing so we need to ensure things
+                // work as expected without it.
+                1 * ItemSize.value,
+                4 * ItemSize.value,
             )
             // contentPadding
             .combineWithParameters(

--- a/lib/src/androidTest/kotlin/dev/chrisbanes/snapper/InstrumentedSnapperFlingLazyRowTest.kt
+++ b/lib/src/androidTest/kotlin/dev/chrisbanes/snapper/InstrumentedSnapperFlingLazyRowTest.kt
@@ -53,9 +53,14 @@ class InstrumentedSnapperFlingLazyRowTest(
         fun data() = parameterizedParams()
             // maxScrollDistanceDp
             .combineWithParameters(
-                // We add 4dp on to cater for itemSpacing
+                // We add 4dp on to cater for item spacing
                 1 * (ItemSize.value + 4),
                 4 * (ItemSize.value + 4),
+                // We also test without adding the item spacing. Key use cases like
+                // Accompanist Pager do not add the item spacing so we need to ensure things
+                // work as expected without it.
+                1 * ItemSize.value,
+                4 * ItemSize.value,
             )
             // contentPadding
             .combineWithParameters(

--- a/lib/src/test/kotlin/dev/chrisbanes/snapper/RobolectricSnapperFlingLazyColumnTest.kt
+++ b/lib/src/test/kotlin/dev/chrisbanes/snapper/RobolectricSnapperFlingLazyColumnTest.kt
@@ -51,10 +51,16 @@ class RobolectricSnapperFlingLazyColumnTest(
         fun data() = parameterizedParams()
             // maxScrollDistanceDp
             .combineWithParameters(
-                // We add 4dp on to cater for itemSpacing
+                // We add 4dp on to cater for item spacing
                 1 * (ItemSize.value + 4),
                 2 * (ItemSize.value + 4),
                 4 * (ItemSize.value + 4),
+                // We also test without adding the item spacing. Key use cases like
+                // Accompanist Pager do not add the item spacing so we need to ensure things
+                // work as expected without it.
+                1 * ItemSize.value,
+                2 * ItemSize.value,
+                4 * ItemSize.value,
             )
             // contentPadding
             .combineWithParameters(

--- a/lib/src/test/kotlin/dev/chrisbanes/snapper/RobolectricSnapperFlingLazyRowTest.kt
+++ b/lib/src/test/kotlin/dev/chrisbanes/snapper/RobolectricSnapperFlingLazyRowTest.kt
@@ -55,10 +55,16 @@ class RobolectricSnapperFlingLazyRowTest(
         fun data() = parameterizedParams()
             // maxScrollDistanceDp
             .combineWithParameters(
-                // We add 4dp on to cater for itemSpacing
+                // We add 4dp on to cater for item spacing
                 1 * (ItemSize.value + 4),
                 2 * (ItemSize.value + 4),
                 4 * (ItemSize.value + 4),
+                // We also test without adding the item spacing. Key use cases like
+                // Accompanist Pager do not add the item spacing so we need to ensure things
+                // work as expected without it.
+                1 * ItemSize.value,
+                2 * ItemSize.value,
+                4 * ItemSize.value,
             )
             // contentPadding
             .combineWithParameters(


### PR DESCRIPTION
This commit updates determineTargetIndex() to be more consistent
with other implementations.

The new implementation is roughly the same as before, but hopefully
clearer to understand. The changes mean that we can now use a round,
rather than a truncate. This which means that flings which travel
most of the distance will now target to the 'next' page. Previously they
would truncate down towards 0.