### PR TITLE
Fix float inaccuracies at high values 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false
       matrix:
-        api-level: [ 22, 26, 28, 29 ]
+        api-level: [ 26, 29 ]
 
     env:
       TERM: dumb

--- a/lib/src/main/kotlin/dev/chrisbanes/snapper/LazyList.kt
+++ b/lib/src/main/kotlin/dev/chrisbanes/snapper/LazyList.kt
@@ -196,26 +196,28 @@ public class LazyListSnapperLayoutInfo(
                 }
             }
 
-        val flingIndexDelta = flingDistance / distancePerItem
-        val currentItemOffsetRatio = distanceToCurrent / distancePerItem
+        val flingIndexDelta = flingDistance / distancePerItem.toDouble()
+        val currentItemOffsetRatio = distanceToCurrent / distancePerItem.toDouble()
 
-        SnapperLog.d {
-            "current item: $curr, " +
-                "current item offset: ${"%.3f".format(currentItemOffsetRatio)}, " +
-                "distancePerItem: $distancePerItem, " +
-                "maximumFlingDistance: ${"%.3f".format(maximumFlingDistance)}, " +
-                "flingDistance: ${"%.3f".format(flingDistance)}, " +
-                "flingIndexDelta: ${"%.3f".format(flingIndexDelta)}"
-        }
+        // The index offset from the current index. We round this value which results in
+        // flings rounding towards the (relative) infinity. The key use case for this is to
+        // support short + fast flings. These could result in a fling distance of ~70% of the
+        // item distance (example). The rounding ensures that we target the next page.
+        val indexOffset = (flingIndexDelta - currentItemOffsetRatio).roundToInt()
 
-        // Our target index, using the fling distance from the current item. We round the value
-        // which results in flings rounding towards the (relative) infinity.
-        // The key use case for this is to support short + fast flings. These could result in a
-        // fling distance of ~70% of the item distance (example). The rounding ensures that
-        // we target the next page.
-        return (curr.index + flingIndexDelta - currentItemOffsetRatio)
-            .roundToInt()
-            .coerceIn(0, itemCount - 1)
+        return (curr.index + indexOffset).coerceIn(0, itemCount - 1)
+            .also { result ->
+                SnapperLog.d {
+                    "determineTargetIndex. " +
+                        "result: $result, " +
+                        "current item: $curr, " +
+                        "current item offset: ${"%.3f".format(currentItemOffsetRatio)}, " +
+                        "distancePerItem: $distancePerItem, " +
+                        "maximumFlingDistance: ${"%.3f".format(maximumFlingDistance)}, " +
+                        "flingDistance: ${"%.3f".format(flingDistance)}, " +
+                        "flingIndexDelta: ${"%.3f".format(flingIndexDelta)}"
+                }
+            }
     }
 
     /**


### PR DESCRIPTION
When determining the target index to fling to, we are currently
including the current index into a float.

This means that if the current scroll index is a large number (millions),
the accuracy of the decimals below that is greatly impacted, enough so to
affect rounding and the calculated scroll index.

This PR fixes that in 2 ways. First, we use double calculations for determining
the index offset. Secondly, we keep the current index out of the double.

Fixes https://github.com/chrisbanes/snapper/issues/13