### PR TITLE
Fix target overscroll on page skips

### DIFF
--- a/lib/src/main/kotlin/dev/chrisbanes/snapper/SnapperFlingBehavior.kt
+++ b/lib/src/main/kotlin/dev/chrisbanes/snapper/SnapperFlingBehavior.kt
@@ -650,10 +650,10 @@ public class SnapperFlingBehavior private constructor(
         targetIndex: Int,
     ): Int = when {
         // forwards
-        initialVelocity > 0 && currentItem.index == targetIndex -> {
+        initialVelocity > 0 && currentItem.index >= targetIndex -> {
             layoutInfo.distanceToIndexSnap(currentItem.index)
         }
-        initialVelocity < 0 && currentItem.index == targetIndex - 1 -> {
+        initialVelocity < 0 && currentItem.index <= targetIndex - 1 -> {
             layoutInfo.distanceToIndexSnap(currentItem.index + 1)
         }
         else -> 0


### PR DESCRIPTION
This fixes issue: https://github.com/google/accompanist/issues/1118

As outlined in https://github.com/google/accompanist/issues/1118#issuecomment-1157410298, when scrolling with a large velocity and the layout is expensive to draw, the `currentItem` index may "skip" some indices. Hence, the equality check did sometimes not trigger.

This fixes this issue by replacing the equality check with the corresponding `>=`/`<=` checks which will trigger the correct snap back on target overscroll.